### PR TITLE
「どうもステータスが更新されないことがあるので」関数を作ったみた

### DIFF
--- a/ebs-extension.rb
+++ b/ebs-extension.rb
@@ -7,24 +7,6 @@ require "yaml"
 require "pp"
 require "optparse"
 
-# Common Functions
-
-#どうもステータスが更新されないことがあるので、n秒待ったら抜ける用関数
-def wait_for_status_changed(target, status, limit, interval)
-
-  elapsed = 0;
-
-  while target.status != status
-    break if elapsed >= limit
-
-    sleep(interval)
-    elapsed += interval
-    
-    pp "wait...  " + elapsed.to_s 
-    pp target.status
-  end 
-
-end
 
 # read config
 config=YAML.load(File.read("./config/config.yml"))
@@ -64,12 +46,8 @@ pp "Shutdown!"
 #インスタンス停止
 pp "stop"
 if instance.status == :running
-  pp "stopping..."
   instance.stop
-  sleep(10)
-  while instance.status != :stopped
-    sleep(2)
-  end
+  wait_for_status_changed(instance, :stopped, 2,"stopping...")
   pp "stop!"
 end
   
@@ -99,17 +77,14 @@ comment = instance_id + "(" + volume_id + ")" + "--" + Time.now.strftime("%Y%m%d
 snapshot = volume.create_snapshot(comment)
 pp "wait..."
 pp snapshot.status
-sleep (10)
-#どうもステータスが更新されないことがあるので、１分待ったら抜ける
-wait_for_status_changed(snapshot, :completed, 60, 2)
+wait_for_status_changed(snapshot, :completed, 2, "creating...")
 
 # スナップショットから容量を拡張したボリュームを作成
+pp "CreateVolume"
 new_volume = snapshot.create_volume(availability_zone,{:size=>volume_size,:snapshot_id =>snapshot.id,:volume_type=>"standard"})
 pp "wait..."
 pp new_volume.status
-sleep (10)
-# どうもステータスが更新されないことがあるので、１分待ったら抜ける
-wait_for_status_changed(new_volume, :available, 60, 2)
+wait_for_status_changed(new_volume, :available, 2, "creating...")
 
 # インスタンスからボリュームをデタッチ
 pp "EBS Detach"
@@ -120,34 +95,34 @@ if detach.status == :error
   pp "Error!! Disk Not Found!!"
   exit 1
 end
-pp "wait..."
-sleep (10)
-#どうもステータスが更新されないことがあるので、１分待ったら抜ける
-wait_for_status_changed(detach, :available, 60, 2)
+wait_for_status_changed(detach, :available, 2)
 
 # インスタンスからボリュームをアタッチ
+pp "Attach"
 attach_volume = ec2.client.attach_volume(:volume_id=>new_volume.id,:instance_id=>instance_id,:device=>device)
 pp attach_volume.status
 
-pp "wait..."
-sleep (10)
-pp attach_volume.status
-#どうもステータスが更新されないことがあるので、１分待ったら抜ける
-wait_for_status_changed(attach_volume, :in_use, 60, 2)
+wait_for_status_changed(attach_volume, :in_use, 2, "Attaching...")
 
 # インスタンス起動
 # startup
 pp "startup"
 if instance.status == :stopped
-  pp "starting..."
   instance.start
-  sleep(10)
-  while instance.status != :running
-    sleep(2)
-  end
+  wait_for_status_changed(instance, :running, 2, "starting...")
   pp "start!"
 end
 
 pp "OK"
 exit 0
 
+# Common Functions
+
+#ステータス更新チェック
+def wait_for_status_changed(target, status, interval. message="wait...")
+  while target.status != status
+    sleep(interval)
+    pp message
+    pp target.status
+  end 
+end

--- a/ebs-extension.rb
+++ b/ebs-extension.rb
@@ -69,20 +69,16 @@ ret = ec2.client.describe_instances(:instance_ids => [instance_id])[:reservation
 
 # ルートボリュームIDからスナップショットを作成
 volume = ec2.volumes[volume_id]
-if !volume.exists?
-  pp "Volume NotFound!!"
-  exit 1
-end 
 comment = instance_id + "(" + volume_id + ")" + "--" + Time.now.strftime("%Y%m%d%H%M") + '--' + "snapshot"
 snapshot = volume.create_snapshot(comment)
-pp "wait..."
+
 pp snapshot.status
 wait_for_status_changed(snapshot, :completed, 2, "creating...")
 
 # スナップショットから容量を拡張したボリュームを作成
 pp "CreateVolume"
 new_volume = snapshot.create_volume(availability_zone,{:size=>volume_size,:snapshot_id =>snapshot.id,:volume_type=>"standard"})
-pp "wait..."
+
 pp new_volume.status
 wait_for_status_changed(new_volume, :available, 2, "creating...")
 


### PR DESCRIPTION
wait_for_status_changed() の第一引数と第二引数はラムダにしたほうがいい気がするけど、Ruby でラムダとか知らんので日和った（汗
動作環境はないので、動かしてはいません（汗 #関数そのものはは部分的に確認したが
制限時間超えたら中断することなくしれっと抜けるのは既設どおりのつもり。

その他
「# インスタンスのルートボリュームIDを取得」のロジックが、直感的にアウトくさい気がするが、読めてないので手を付けてない。
